### PR TITLE
:bookmark: release 0.8.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,0 +1,5 @@
+0.8.0 (2019-07-12)
+==================
+
+* Use Django's MiddlewareMixin for compatibility with newer versions
+  of Django.


### PR DESCRIPTION
This contains a middleware fix that allows django-audit-log
to be compatible with newer versions of Django.

See: https://github.com/vvangelovski/django-audit-log/pull/47